### PR TITLE
feat: add jwt auth and password hashing

### DIFF
--- a/services/api-worker/migrations/0004_user_password.sql
+++ b/services/api-worker/migrations/0004_user_password.sql
@@ -1,0 +1,3 @@
+-- Add password hash and salt columns to users
+ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';
+ALTER TABLE users ADD COLUMN password_salt TEXT NOT NULL DEFAULT '';

--- a/services/api-worker/migrations/0004_user_password.sql
+++ b/services/api-worker/migrations/0004_user_password.sql
@@ -1,3 +1,3 @@
 -- Add password hash and salt columns to users
-ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';
-ALTER TABLE users ADD COLUMN password_salt TEXT NOT NULL DEFAULT '';
+ALTER TABLE users ADD COLUMN password_hash TEXT;
+ALTER TABLE users ADD COLUMN password_salt TEXT;

--- a/services/api-worker/src/index.ts
+++ b/services/api-worker/src/index.ts
@@ -255,7 +255,10 @@ export default {
         const ok = await verifyPassword(body.password, user.password_hash, user.password_salt);
         if (!ok) return unauthorized();
         const payload = { sub: user.user_id, tenant_id: user.tenant_id, role: user.role, exp: Math.floor(Date.now() / 1000) + 3600 };
-        const token = await signJwt(payload, env.JWT_SECRET || '');
+        if (!env.JWT_SECRET) {
+          return serverError('JWT_SECRET is not configured on the server');
+        }
+        const token = await signJwt(payload, env.JWT_SECRET);
         return send({ token, user: { user_id: user.user_id, tenant_id: user.tenant_id, email: user.email, role: user.role } });
       } catch (e: any) {
         return serverError(e?.message);

--- a/services/api-worker/src/index.ts
+++ b/services/api-worker/src/index.ts
@@ -8,7 +8,7 @@ export interface Env {
   RL_WINDOW_SECONDS?: string; // e.g., "60"
   RL_MAX_REQUESTS?: string;   // default for unauthenticated/public
   RL_MAX_REQUESTS_AUTH?: string; // for authenticated (API token/key)
-  DEV_LOGIN_ENABLED?: string; // "true" to enable /auth/login for local/dev only
+  JWT_SECRET?: string; // secret for JWT signing
 }
 // Import OpenAPI spec so it's bundled
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -75,10 +75,67 @@ async function sha256Hex(input: string): Promise<string> {
   return toHex(digest);
 }
 
+// Password hashing using random salt + SHA-256
+async function hashPassword(password: string): Promise<{ hash: string; salt: string }> {
+  const saltBytes = crypto.getRandomValues(new Uint8Array(16));
+  const saltHex = toHex(saltBytes.buffer);
+  const hash = await sha256Hex(saltHex + password);
+  return { hash, salt: saltHex };
+}
+
+async function verifyPassword(password: string, hash: string, salt: string): Promise<boolean> {
+  const check = await sha256Hex(salt + password);
+  return check === hash;
+}
+
+// Minimal JWT implementation (HS256)
+function base64UrlEncode(buffer: ArrayBuffer | Uint8Array): string {
+  const bytes = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+  let binary = '';
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+/g, '');
+}
+
+function base64UrlDecode(str: string): Uint8Array {
+  str = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = str.length % 4;
+  if (pad) str += '='.repeat(4 - pad);
+  const binary = atob(str);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+async function signJwt(payload: Record<string, any>, secret: string): Promise<string> {
+  const header = { alg: 'HS256', typ: 'JWT' };
+  const enc = (obj: any) => base64UrlEncode(new TextEncoder().encode(JSON.stringify(obj)));
+  const h = enc(header);
+  const p = enc(payload);
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(data));
+  const s = base64UrlEncode(signature);
+  return `${data}.${s}`;
+}
+
+async function verifyJwt(token: string, secret: string): Promise<Record<string, any> | null> {
+  const parts = token.split('.');
+  if (parts.length !== 3) return null;
+  const [h, p, s] = parts;
+  const data = `${h}.${p}`;
+  const key = await crypto.subtle.importKey('raw', new TextEncoder().encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, ['verify']);
+  const valid = await crypto.subtle.verify('HMAC', key, base64UrlDecode(s).buffer as ArrayBuffer, new TextEncoder().encode(data));
+  if (!valid) return null;
+  const payload = JSON.parse(new TextDecoder().decode(base64UrlDecode(p)));
+  if (payload.exp && Date.now() / 1000 > payload.exp) return null;
+  return payload;
+}
+
 type AuthContext = {
   admin: boolean;
-  tenantId?: string; // when using per-tenant API key
-  actor: string; // identifier for rate-limiting (e.g., ip:..., api:<hash>, admin)
+  tenantId?: string; // tenant from API key or JWT
+  userId?: string; // when using user JWT
+  actor: string; // identifier for rate-limiting (e.g., ip:..., api:<hash>, admin, user:<id>)
 };
 
 // Rate limiting using KV (fixed window)
@@ -158,15 +215,22 @@ export default {
         authCtx = { admin: true, actor: 'admin' };
       } else {
         const mkey = /^t_([a-z0-9-]{8,})\.(.+)$/i.exec(secret);
-        if (!mkey) return unauthorized();
-        const tenantId = mkey[1];
-        const keyPlain = mkey[2];
-        const keyHash = await sha256Hex(keyPlain);
-        const found = await env.DB.prepare('SELECT tenant_id FROM tenant_api_keys WHERE tenant_id = ?1 AND key_hash = ?2 AND active = 1')
-          .bind(tenantId, keyHash)
-          .first<{ tenant_id: string }>();
-        if (!found) return unauthorized();
-        authCtx = { admin: false, tenantId, actor: `api:${keyHash.slice(0,16)}` };
+        if (mkey) {
+          const tenantId = mkey[1];
+          const keyPlain = mkey[2];
+          const keyHash = await sha256Hex(keyPlain);
+          const found = await env.DB.prepare('SELECT tenant_id FROM tenant_api_keys WHERE tenant_id = ?1 AND key_hash = ?2 AND active = 1')
+            .bind(tenantId, keyHash)
+            .first<{ tenant_id: string }>();
+          if (!found) return unauthorized();
+          authCtx = { admin: false, tenantId, actor: `api:${keyHash.slice(0,16)}` };
+        } else if (env.JWT_SECRET) {
+          const jwt = await verifyJwt(secret, env.JWT_SECRET);
+          if (!jwt) return unauthorized();
+          authCtx = { admin: false, tenantId: jwt.tenant_id, userId: jwt.sub, actor: `user:${jwt.sub}` };
+        } else {
+          return unauthorized();
+        }
       }
     }
 
@@ -177,63 +241,22 @@ export default {
 
     // Health
   if (path === '/health') return send({ status: 'ok', service: 'c360-api' });
-    // Development-only auth: exchange email/password for a tenant API key
+    // User login, returns JWT
     if (path === '/auth/login' && method === 'POST') {
       try {
-        if ((env.DEV_LOGIN_ENABLED || '').toLowerCase() !== 'true') {
-          return notFound();
-        }
-        const body = await readJson<{ email?: string; password?: string; tenant_id?: string; }>(request);
+        const body = await readJson<{ email?: string; password?: string }>(request);
         if (!body?.email) return badRequest('email is required');
         if (!isEmail(body.email)) return badRequest('invalid email');
-        if (!body?.password || body.password.length < 8) return badRequest('invalid password');
-
-        // Resolve tenant
-        let tenantId = body.tenant_id;
-        let tenantName: string | undefined;
-        if (tenantId) {
-          const found = await env.DB.prepare('SELECT tenant_id, name, created_at FROM tenants WHERE tenant_id = ?1')
-            .bind(tenantId)
-            .first<{ tenant_id: string; name: string; created_at: string }>();
-          if (!found) return badRequest('tenant not found');
-          tenantName = found.name;
-        } else {
-          // Create a dev tenant if none provided
-          tenantId = crypto.randomUUID();
-          tenantName = `Dev Tenant (${body.email})`;
-          await env.DB.prepare('INSERT INTO tenants (tenant_id, name) VALUES (?1, ?2)')
-            .bind(tenantId, tenantName)
-            .run();
-        }
-
-        // Upsert user within tenant
-        let user = await env.DB.prepare('SELECT user_id, tenant_id, email, role, created_at FROM users WHERE tenant_id = ?1 AND email = ?2')
-          .bind(tenantId, body.email)
-          .first<{ user_id: string; tenant_id: string; email: string; role: string; created_at: string }>();
-        if (!user) {
-          const uid = crypto.randomUUID();
-          await env.DB.prepare('INSERT INTO users (user_id, tenant_id, email, role) VALUES (?1, ?2, ?3, ?4)')
-            .bind(uid, tenantId, body.email, 'member')
-            .run();
-          user = await env.DB.prepare('SELECT user_id, tenant_id, email, role, created_at FROM users WHERE user_id = ?1')
-            .bind(uid)
-            .first<{ user_id: string; tenant_id: string; email: string; role: string; created_at: string }>();
-        }
-
-        // Issue a tenant API key
-        const raw = crypto.randomUUID().replace(/-/g, '') + crypto.randomUUID().replace(/-/g, '');
-        const keyHash = await sha256Hex(raw);
-        await env.DB.prepare('INSERT INTO tenant_api_keys (tenant_id, key_hash, active, created_at) VALUES (?1, ?2, 1, datetime("now"))')
-          .bind(tenantId, keyHash)
-          .run();
-        const apiKey = `t_${tenantId}.${raw}`;
-
-        return send({
-          api_key: apiKey,
-          tenant_id: tenantId,
-          tenant: tenantName ? { tenant_id: tenantId, name: tenantName } : { tenant_id: tenantId },
-          user
-        }, 200);
+        if (!body?.password) return badRequest('password is required');
+        const user = await env.DB.prepare('SELECT user_id, tenant_id, email, role, password_hash, password_salt FROM users WHERE email = ?1')
+          .bind(body.email)
+          .first<{ user_id: string; tenant_id: string; email: string; role: string; password_hash: string; password_salt: string }>();
+        if (!user) return unauthorized();
+        const ok = await verifyPassword(body.password, user.password_hash, user.password_salt);
+        if (!ok) return unauthorized();
+        const payload = { sub: user.user_id, tenant_id: user.tenant_id, role: user.role, exp: Math.floor(Date.now() / 1000) + 3600 };
+        const token = await signJwt(payload, env.JWT_SECRET || '');
+        return send({ token, user: { user_id: user.user_id, tenant_id: user.tenant_id, email: user.email, role: user.role } });
       } catch (e: any) {
         return serverError(e?.message);
       }
@@ -271,6 +294,18 @@ export default {
       try {
         if (authCtx.admin) {
           return send({ admin: true });
+        }
+        if (authCtx.userId) {
+          const user = await env.DB.prepare('SELECT user_id, tenant_id, email, role FROM users WHERE user_id = ?1')
+            .bind(authCtx.userId)
+            .first<{ user_id: string; tenant_id: string; email: string; role: string }>();
+          let tenant: any = undefined;
+          if (user) {
+            tenant = await env.DB.prepare('SELECT tenant_id, name, created_at FROM tenants WHERE tenant_id = ?1')
+              .bind(user.tenant_id)
+              .first<{ tenant_id: string; name: string; created_at: string }>();
+          }
+          return send({ admin: false, user, tenant });
         }
         if (authCtx.tenantId) {
           const t = await env.DB.prepare('SELECT tenant_id, name, created_at FROM tenants WHERE tenant_id = ?1')
@@ -393,17 +428,19 @@ export default {
         }
       }
       if (m && method === 'POST') {
-        const body = await readJson<{ email?: string; role?: string }>(request);
+        const body = await readJson<{ email?: string; role?: string; password?: string }>(request);
         if (!body?.email) return badRequest('email is required');
-  if (!isEmail(body.email)) return badRequest('invalid email');
-  const role = body.role || 'member';
-  if (!allowedRoles.has(role)) return badRequest('invalid role');
+        if (!isEmail(body.email)) return badRequest('invalid email');
+        const role = body.role || 'member';
+        if (!allowedRoles.has(role)) return badRequest('invalid role');
+        if (!body?.password || body.password.length < 8) return badRequest('password must be at least 8 characters');
+        const { hash, salt } = await hashPassword(body.password);
         const userId = crypto.randomUUID();
         try {
           await env.DB.prepare(
-            'INSERT INTO users (user_id, tenant_id, email, role) VALUES (?1, ?2, ?3, ?4)'
+            'INSERT INTO users (user_id, tenant_id, email, role, password_hash, password_salt) VALUES (?1, ?2, ?3, ?4, ?5, ?6)'
           )
-            .bind(userId, m[1], body.email, role)
+            .bind(userId, m[1], body.email, role, hash, salt)
             .run();
           const { results } = await env.DB.prepare(
             'SELECT user_id, tenant_id, email, role, created_at FROM users WHERE user_id = ?1'

--- a/services/api-worker/src/index.ts
+++ b/services/api-worker/src/index.ts
@@ -248,10 +248,8 @@ export default {
         if (!body?.email) return badRequest('email is required');
         if (!isEmail(body.email)) return badRequest('invalid email');
         if (!body?.password) return badRequest('password is required');
-        const user = await env.DB.prepare('SELECT user_id, tenant_id, email, role, password_hash, password_salt FROM users WHERE email = ?1')
-          .bind(body.email)
-          .first<{ user_id: string; tenant_id: string; email: string; role: string; password_hash: string; password_salt: string }>();
         if (!user) return unauthorized();
+        if (!user.password_hash || !user.password_salt) return unauthorized();
         const ok = await verifyPassword(body.password, user.password_hash, user.password_salt);
         if (!ok) return unauthorized();
         const payload = { sub: user.user_id, tenant_id: user.tenant_id, role: user.role, exp: Math.floor(Date.now() / 1000) + 3600 };

--- a/services/api-worker/test/api.test.ts
+++ b/services/api-worker/test/api.test.ts
@@ -14,10 +14,32 @@ describe('api worker', () => {
   });
 
   it('tenants list returns array', async () => {
-    const env = { DB: new MockD1(), KV: new Map() } as any;
-    const res = await worker.fetch(makeRequest('/tenants'), env, {} as any);
+    const kv = new Map<string, string>();
+    const env = { DB: new MockD1(), KV: { get: async (k: string) => kv.get(k) ?? null, put: async (k: string, v: string) => { kv.set(k, v); } }, API_TOKEN: 'admintoken', JWT_SECRET: 'secret' } as any;
+    const res = await worker.fetch(makeRequest('/tenants', { headers: { authorization: 'Bearer admintoken' } }), env, {} as any);
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(Array.isArray(data)).toBe(true);
+  });
+
+  it('login returns JWT for valid credentials', async () => {
+    const kv = new Map<string, string>();
+    const env: any = { DB: new MockD1(), KV: { get: async (k: string) => kv.get(k) ?? null, put: async (k: string, v: string) => { kv.set(k, v); } }, API_TOKEN: 'admintoken', JWT_SECRET: 'secret' };
+    // create tenant
+    let res = await worker.fetch(makeRequest('/tenants', { method: 'POST', body: JSON.stringify({ name: 'T' }), headers: { 'content-type': 'application/json', authorization: 'Bearer admintoken' } }), env, {} as any);
+    const tenant = await res.json() as any;
+    // create user with password
+    res = await worker.fetch(makeRequest(`/tenants/${tenant.tenant_id}/users`, { method: 'POST', body: JSON.stringify({ email: 'a@ex.com', role: 'admin', password: 'password123' }), headers: { 'content-type': 'application/json', authorization: 'Bearer admintoken' } }), env, {} as any);
+    expect(res.status).toBe(200);
+    // login
+    res = await worker.fetch(makeRequest('/auth/login', { method: 'POST', body: JSON.stringify({ email: 'a@ex.com', password: 'password123' }), headers: { 'content-type': 'application/json' } }), env, {} as any);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(typeof data.token).toBe('string');
+    // whoami with token
+    res = await worker.fetch(makeRequest('/whoami', { headers: { authorization: `Bearer ${data.token}` } }), env, {} as any);
+    expect(res.status).toBe(200);
+    const who = await res.json() as any;
+    expect(who.user.email).toBe('a@ex.com');
   });
 });

--- a/services/api-worker/test/utils/mockD1.ts
+++ b/services/api-worker/test/utils/mockD1.ts
@@ -33,6 +33,10 @@ export class MockD1 {
                 const [userId] = args;
                 return { results: self.users.filter(u => u.user_id === userId) };
               }
+              if (lower.includes('where email = ?1')) {
+                const [email] = args;
+                return { results: self.users.filter(u => u.email === email) };
+              }
               return { results: [...self.users] };
             }
             return { results: [] };
@@ -45,8 +49,13 @@ export class MockD1 {
               return { meta: { changes: 1 } } as any;
             }
             if (lower.startsWith('insert into users')) {
-              const [user_id, tenant_id, email, role] = args;
-              self.users.push({ user_id, tenant_id, email, role, created_at: new Date().toISOString() });
+              if (args.length === 4) {
+                const [user_id, tenant_id, email, role] = args;
+                self.users.push({ user_id, tenant_id, email, role, created_at: new Date().toISOString() });
+              } else {
+                const [user_id, tenant_id, email, role, password_hash, password_salt] = args;
+                self.users.push({ user_id, tenant_id, email, role, password_hash, password_salt, created_at: new Date().toISOString() });
+              }
               return { meta: { changes: 1 } } as any;
             }
             // UPDATES
@@ -79,6 +88,10 @@ export class MockD1 {
               return { meta: { changes: before - self.users.length } } as any;
             }
             return { meta: { changes: 0 } } as any;
+          },
+          async first() {
+            const { results } = await (this as any).all();
+            return (results as any[])[0] ?? null;
           }
         };
       }

--- a/services/api-worker/wrangler.toml
+++ b/services/api-worker/wrangler.toml
@@ -17,7 +17,7 @@ id = "a258aa13ae6542d28b2f3200b206cc69" # TODO: replace with real KV id
 [vars]
 # Local/dev default CORS (override in envs below). Use either CORS_ORIGIN (single) or CORS_ORIGINS (comma-separated).
 CORS_ORIGIN = "http://localhost:5173"
-DEV_LOGIN_ENABLED = "true"
+JWT_SECRET = "devsecret"
 
 # Staging environment
 [env.staging]


### PR DESCRIPTION
## Summary
- implement password hashing and minimal JWT utilities
- replace dev login flow with hashed credential authentication
- persist user password hashes via migration

## Testing
- `npm test --prefix services/api-worker`
- `npm run check --prefix services/api-worker`


------
https://chatgpt.com/codex/tasks/task_e_68b337066d38832f9eac312d496f70df