### PR TITLE
Restrict tenant APIs to authorized tokens

### DIFF
--- a/services/api-worker/test/api.test.ts
+++ b/services/api-worker/test/api.test.ts
@@ -2,8 +2,11 @@ import { describe, it, expect } from 'vitest';
 import worker from '../src/index';
 import { MockD1 } from './utils/mockD1';
 
-const makeRequest = (path: string, init?: RequestInit) =>
-  new Request(`http://localhost${path}`, init);
+const makeRequest = (path: string, init: RequestInit = {}) => {
+  const headers = new Headers(init.headers || {});
+  headers.set('authorization', 'Bearer admin');
+  return new Request(`http://localhost${path}`, { ...init, headers });
+};
 
 describe('api worker', () => {
   it('health endpoint works', async () => {
@@ -14,7 +17,12 @@ describe('api worker', () => {
   });
 
   it('tenants list returns array', async () => {
-    const env = { DB: new MockD1(), KV: new Map() } as any;
+    const kv: any = {
+      store: new Map<string, string>(),
+      async get(key: string) { return this.store.get(key) ?? null; },
+      async put(key: string, value: string) { this.store.set(key, value); }
+    };
+    const env = { DB: new MockD1(), KV: kv, API_TOKEN: 'admin' } as any;
     const res = await worker.fetch(makeRequest('/tenants'), env, {} as any);
     expect(res.status).toBe(200);
     const data = await res.json();

--- a/services/api-worker/test/crud.test.ts
+++ b/services/api-worker/test/crud.test.ts
@@ -2,11 +2,20 @@ import { describe, it, expect } from 'vitest';
 import worker from '../src/index';
 import { MockD1 } from './utils/mockD1';
 
-const make = (path: string, init?: RequestInit) => new Request(`http://localhost${path}`, init);
+const make = (path: string, init: RequestInit = {}) => {
+  const headers = new Headers(init.headers || {});
+  headers.set('authorization', 'Bearer admin');
+  return new Request(`http://localhost${path}`, { ...init, headers });
+};
 
 describe('tenants and users CRUD', () => {
   it('tenant CRUD happy path', async () => {
-    const env: any = { DB: new MockD1(), KV: new Map() };
+    const kv: any = {
+      store: new Map<string, string>(),
+      async get(key: string) { return this.store.get(key) ?? null; },
+      async put(key: string, value: string) { this.store.set(key, value); }
+    };
+    const env: any = { DB: new MockD1(), KV: kv, API_TOKEN: 'admin' };
 
     // list empty
     let res = await worker.fetch(make('/tenants'), env, {} as any);
@@ -44,7 +53,12 @@ describe('tenants and users CRUD', () => {
   });
 
   it('user CRUD under tenant', async () => {
-    const env: any = { DB: new MockD1(), KV: new Map() };
+    const kv2: any = {
+      store: new Map<string, string>(),
+      async get(key: string) { return this.store.get(key) ?? null; },
+      async put(key: string, value: string) { this.store.set(key, value); }
+    };
+    const env: any = { DB: new MockD1(), KV: kv2, API_TOKEN: 'admin' };
 
     // create tenant
     let res = await worker.fetch(make('/tenants', { method: 'POST', body: JSON.stringify({ name: 'T' }), headers: { 'content-type': 'application/json' } }), env, {} as any);
@@ -99,7 +113,12 @@ describe('tenants and users CRUD', () => {
   });
 
   it('returns 400/404 appropriately', async () => {
-    const env: any = { DB: new MockD1(), KV: new Map() };
+    const kv3: any = {
+      store: new Map<string, string>(),
+      async get(key: string) { return this.store.get(key) ?? null; },
+      async put(key: string, value: string) { this.store.set(key, value); }
+    };
+    const env: any = { DB: new MockD1(), KV: kv3, API_TOKEN: 'admin' };
 
     // POST tenant without body
     let res = await worker.fetch(make('/tenants', { method: 'POST', body: '{}', headers: { 'content-type': 'application/json' } }), env, {} as any);


### PR DESCRIPTION
## Summary
- gate tenant list and creation to admin tokens
- enforce tenant scoping for /tenants/:id and nested user routes
- update tests for admin auth and KV stub

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b33707a054832fb54619f6a44e9614