### PR TITLE
chore: enforce strict CORS origins

### DIFF
--- a/services/api-worker/wrangler.toml
+++ b/services/api-worker/wrangler.toml
@@ -34,7 +34,6 @@ id = "3c5041f70b394827b3e853c18d03e290" # TODO: replace with real KV id
 
 [env.staging.vars]
 # Allow only staging app origins
-CORS_ORIGIN = "https://staging.app.example.com" # single-origin fallback; not inherited from top-level
 CORS_ORIGINS = "https://staging.app.example.com,https://staging.admin.example.com"
 
 # Production environment
@@ -52,7 +51,6 @@ id = "9ac7ff65e9b94796b007b2bc156a7d2d" # TODO: replace with real KV id
 
 [env.production.vars]
 # Lock down to exact production origins
-CORS_ORIGIN = "https://app.example.com" # single-origin fallback; not inherited from top-level
 CORS_ORIGINS = "https://app.example.com,https://admin.example.com"
 
 # Note: Do NOT put API_TOKEN in this file. Set it securely via:


### PR DESCRIPTION
## Summary
- remove single CORS_ORIGIN fallbacks for staging and production workers
- lock down staging and production CORS_ORIGINS to explicit app domains

## Testing
- `npm test` (fails: expected 401 to be 200)


------
https://chatgpt.com/codex/tasks/task_e_68b33709be78832f9e704515c09bc688