### PR TITLE
feat(api-worker): add structured logging

### DIFF
--- a/services/api-worker/wrangler.toml
+++ b/services/api-worker/wrangler.toml
@@ -18,6 +18,8 @@ id = "a258aa13ae6542d28b2f3200b206cc69" # TODO: replace with real KV id
 # Local/dev default CORS (override in envs below). Use either CORS_ORIGIN (single) or CORS_ORIGINS (comma-separated).
 CORS_ORIGIN = "http://localhost:5173"
 DEV_LOGIN_ENABLED = "true"
+# Optional external log sink endpoint for structured logs
+LOG_SINK_URL = ""
 
 # Staging environment
 [env.staging]


### PR DESCRIPTION
## Summary
- implement structured JSON logger with optional external sink
- record auth failures and CRUD events for tenants, users and API keys
- expose `LOG_SINK_URL` in wrangler config for log forwarding

## Testing
- `cd services/api-worker && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3370ba724832fbb780b785bd4edbf