### PR TITLE
chore: update wrangler configuration

### DIFF
--- a/services/api-worker/.dev.vars.example
+++ b/services/api-worker/.dev.vars.example
@@ -2,5 +2,4 @@
 # Local CORS origin for your frontend
 CORS_ORIGIN="http://localhost:5173"
 
-# Optional: require Bearer token locally
-# API_TOKEN="local-dev-token"
+# Secrets such as API_TOKEN should be set with `wrangler secret put` and not stored here.

--- a/services/api-worker/README.md
+++ b/services/api-worker/README.md
@@ -15,7 +15,7 @@ Endpoints:
 
 Notes:
 - Use Wrangler D1 migrations to apply SQL in migrations/ to your bound database.
-- Update `wrangler.toml` with real D1 `database_id` and KV `id` before deploy.
+- Wrangler configuration includes production D1 database and KV namespace IDs; update only if infrastructure changes.
 
 Environment variables:
 - CORS_ORIGINS: Comma-separated allowlist of origins. If set, the Worker reflects the request Origin when it matches; otherwise returns `access-control-allow-origin: null`.

--- a/services/api-worker/wrangler.toml
+++ b/services/api-worker/wrangler.toml
@@ -12,7 +12,7 @@ database_id = "e5539a46-e857-4677-8ba4-ff5798cc0e25"
 
 [[kv_namespaces]]
 binding = "KV"
-id = "a258aa13ae6542d28b2f3200b206cc69" # TODO: replace with real KV id
+id = "5d3248fa61d24658a531ffd3e8acb364"
 
 [vars]
 # Local/dev default CORS (override in envs below). Use either CORS_ORIGIN (single) or CORS_ORIGINS (comma-separated).
@@ -30,7 +30,7 @@ database_id = "448cd3be-4117-4d6c-bb44-cf89ec21637f"
 
 [[env.staging.kv_namespaces]]
 binding = "KV"
-id = "3c5041f70b394827b3e853c18d03e290" # TODO: replace with real KV id
+id = "b1cbe9efcb714cf0b2246b9a49393ce8"
 
 [env.staging.vars]
 # Allow only staging app origins
@@ -48,7 +48,7 @@ database_id = "3cdf8d89-79b4-42de-83db-5446d97d49e8"
 
 [[env.production.kv_namespaces]]
 binding = "KV"
-id = "9ac7ff65e9b94796b007b2bc156a7d2d" # TODO: replace with real KV id
+id = "de8c3fc1b2454ef5bb0a5dd1eeb2d971"
 
 [env.production.vars]
 # Lock down to exact production origins

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,5 +1,6 @@
-# Root placeholder. Each Worker/service will define its own wrangler.toml
-# in its respective folder (e.g., services/api-worker/wrangler.toml).
+# Root configuration placeholder for Worker services. Each Worker/service
+# defines its own `wrangler.toml` in its folder (e.g.,
+# `services/api-worker/wrangler.toml`).
 
 # Example snippet for a service-level wrangler.toml:
 # name = "c360-api"
@@ -9,5 +10,5 @@
 # enabled = true
 # [[d1_databases]]
 # binding = "DB"
-# database_name = "c360_dev"
-# database_id = "<uuid>"
+# database_name = "c360_prod"
+# database_id = "3cdf8d89-79b4-42de-83db-5446d97d49e8"


### PR DESCRIPTION
## Summary
- replace placeholder KV IDs with production namespace IDs
- document using `wrangler secret` for API_TOKEN and remove example secret
- clarify wrangler configuration in README example

## Testing
- `npm test` (fails: tenants endpoints require auth)

------
https://chatgpt.com/codex/tasks/task_e_68b3370cdd34832fbc778484461674c9