### PR TITLE
feat: add jwt auth and password hashing

### DIFF
--- a/services/api-worker/migrations/0004_user_password.sql
+++ b/services/api-worker/migrations/0004_user_password.sql
@@ -1,0 +1,3 @@
+-- Add password hash and salt columns to users
+ALTER TABLE users ADD COLUMN password_hash TEXT NOT NULL DEFAULT '';
+ALTER TABLE users ADD COLUMN password_salt TEXT NOT NULL DEFAULT '';

--- a/services/api-worker/package-lock.json
+++ b/services/api-worker/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "c360-api-worker",
       "version": "0.1.0",
+      "dependencies": {
+        "bcryptjs": "^2.4.3"
+      },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20240821.0",
         "miniflare": "^3.20240821.0",
@@ -1894,6 +1897,12 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==",
+      "license": "MIT"
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",

--- a/services/api-worker/package.json
+++ b/services/api-worker/package.json
@@ -21,6 +21,9 @@
     "typescript": "^5.5.4",
     "vitest": "^2.0.5",
     "vitest-environment-miniflare": "^2.14.4",
-  "wrangler": "^4.0.0"
+    "wrangler": "^4.0.0"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3"
   }
 }

--- a/services/api-worker/test/api.test.ts
+++ b/services/api-worker/test/api.test.ts
@@ -14,10 +14,32 @@ describe('api worker', () => {
   });
 
   it('tenants list returns array', async () => {
-    const env = { DB: new MockD1(), KV: new Map() } as any;
-    const res = await worker.fetch(makeRequest('/tenants'), env, {} as any);
+    const kv = new Map<string, string>();
+    const env = { DB: new MockD1(), KV: { get: async (k: string) => kv.get(k) ?? null, put: async (k: string, v: string) => { kv.set(k, v); } }, API_TOKEN: 'admintoken', JWT_SECRET: 'secret' } as any;
+    const res = await worker.fetch(makeRequest('/tenants', { headers: { authorization: 'Bearer admintoken' } }), env, {} as any);
     expect(res.status).toBe(200);
     const data = await res.json();
     expect(Array.isArray(data)).toBe(true);
+  });
+
+  it('login returns JWT for valid credentials', async () => {
+    const kv = new Map<string, string>();
+    const env: any = { DB: new MockD1(), KV: { get: async (k: string) => kv.get(k) ?? null, put: async (k: string, v: string) => { kv.set(k, v); } }, API_TOKEN: 'admintoken', JWT_SECRET: 'secret' };
+    // create tenant
+    let res = await worker.fetch(makeRequest('/tenants', { method: 'POST', body: JSON.stringify({ name: 'T' }), headers: { 'content-type': 'application/json', authorization: 'Bearer admintoken' } }), env, {} as any);
+    const tenant = await res.json() as any;
+    // create user with password
+    res = await worker.fetch(makeRequest(`/tenants/${tenant.tenant_id}/users`, { method: 'POST', body: JSON.stringify({ email: 'a@ex.com', role: 'admin', password: 'password123' }), headers: { 'content-type': 'application/json', authorization: 'Bearer admintoken' } }), env, {} as any);
+    expect(res.status).toBe(200);
+    // login
+    res = await worker.fetch(makeRequest('/auth/login', { method: 'POST', body: JSON.stringify({ email: 'a@ex.com', password: 'password123' }), headers: { 'content-type': 'application/json' } }), env, {} as any);
+    expect(res.status).toBe(200);
+    const data = await res.json() as any;
+    expect(typeof data.token).toBe('string');
+    // whoami with token
+    res = await worker.fetch(makeRequest('/whoami', { headers: { authorization: `Bearer ${data.token}` } }), env, {} as any);
+    expect(res.status).toBe(200);
+    const who = await res.json() as any;
+    expect(who.user.email).toBe('a@ex.com');
   });
 });

--- a/services/api-worker/test/utils/mockD1.ts
+++ b/services/api-worker/test/utils/mockD1.ts
@@ -33,6 +33,10 @@ export class MockD1 {
                 const [userId] = args;
                 return { results: self.users.filter(u => u.user_id === userId) };
               }
+              if (lower.includes('where email = ?1')) {
+                const [email] = args;
+                return { results: self.users.filter(u => u.email === email) };
+              }
               return { results: [...self.users] };
             }
             return { results: [] };
@@ -45,8 +49,13 @@ export class MockD1 {
               return { meta: { changes: 1 } } as any;
             }
             if (lower.startsWith('insert into users')) {
-              const [user_id, tenant_id, email, role] = args;
-              self.users.push({ user_id, tenant_id, email, role, created_at: new Date().toISOString() });
+              if (args.length === 4) {
+                const [user_id, tenant_id, email, role] = args;
+                self.users.push({ user_id, tenant_id, email, role, created_at: new Date().toISOString() });
+              } else {
+                const [user_id, tenant_id, email, role, password_hash, password_salt] = args;
+                self.users.push({ user_id, tenant_id, email, role, password_hash, password_salt, created_at: new Date().toISOString() });
+              }
               return { meta: { changes: 1 } } as any;
             }
             // UPDATES
@@ -79,6 +88,10 @@ export class MockD1 {
               return { meta: { changes: before - self.users.length } } as any;
             }
             return { meta: { changes: 0 } } as any;
+          },
+          async first() {
+            const { results } = await (this as any).all();
+            return (results as any[])[0] ?? null;
           }
         };
       }

--- a/services/api-worker/wrangler.toml
+++ b/services/api-worker/wrangler.toml
@@ -17,7 +17,7 @@ id = "a258aa13ae6542d28b2f3200b206cc69" # TODO: replace with real KV id
 [vars]
 # Local/dev default CORS (override in envs below). Use either CORS_ORIGIN (single) or CORS_ORIGINS (comma-separated).
 CORS_ORIGIN = "http://localhost:5173"
-DEV_LOGIN_ENABLED = "true"
+JWT_SECRET = "devsecret"
 
 # Staging environment
 [env.staging]


### PR DESCRIPTION
## Summary
- implement password hashing and minimal JWT utilities
- replace dev login flow with hashed credential authentication
- persist user password hashes via migration
- switch password hashing to bcrypt

## Testing
- `npm test --prefix services/api-worker`
- `npm run check --prefix services/api-worker`


------
https://chatgpt.com/codex/tasks/task_e_68b337066d38832f9eac312d496f70df